### PR TITLE
fixing license tag in package.xml to conform to SPDX

### DIFF
--- a/tcb_span/package.xml
+++ b/tcb_span/package.xml
@@ -6,7 +6,7 @@
   <description>Implementation of C++20's std::span</description>
   <maintainer email="maybe@tylerjw.dev">Tyler Weaver</maintainer>
 
-  <license>Boost Software License</license>
+  <license>BSL-1.0</license>
   <url>https://github.com/tcbrindle/span</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/tl_expected/package.xml
+++ b/tl_expected/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="maybe@tylerjw.dev">Tyler Weaver</maintainer>
 
   <author>Sy Brand</author>
-  <license>Creative Commons Zero v1.0 Universal</license>
+  <license>CC0-1.0</license>
   <url>https://github.com/TartanLlama/expected</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
Updating the package.xml license tags to hold valid SPDX qualifiers. The rationale behind this is, that with
[meta-ros](https://github.com/ros/meta-ros) and
[superflore](https://github.com/ros-infrastructure/superflore) recipes get generated for the OpenEmbedded Linux build system. It will fetch the license tag and copy it over into the recipe. If no valid SPDX identifiers get found, it will issue an error, and a manual step to fix this is needed.

See the SPDX identifiers [CC0-1.0](https://spdx.org/licenses/CC0-1.0) and [BSL-1.0](https://spdx.org/licenses/BSL-1.0.html)