### PR TITLE
Move deprecation warning outside of include guards

### DIFF
--- a/tl_expected/include/tl_expected/expected.hpp
+++ b/tl_expected/include/tl_expected/expected.hpp
@@ -13,9 +13,6 @@
 // <http://creativecommons.org/publicdomain/zero/1.0/>.
 ///
 
-#ifndef TL_EXPECTED_HPP
-#define TL_EXPECTED_HPP
-
 #ifdef _WIN32
 #pragma message( \
   "tl_expected/expected.hpp is deprecated and will be removed by the ROS 2 Lyrical Luth release. \
@@ -26,6 +23,8 @@
   Use <tl/expected.hpp> from libexpected-dev, or <rcpputils/tl_expected/expected.hpp> if the system header is not available."   // NOLINT
 #endif
 
+#ifndef TL_EXPECTED_HPP
+#define TL_EXPECTED_HPP
 
 #define TL_EXPECTED_VERSION_MAJOR 1
 #define TL_EXPECTED_VERSION_MINOR 2


### PR DESCRIPTION
I was wondering why custom validators work at all on humble now, as we have merged the change in RSL but haven't redirected to the system header in cpp_polyfills on humble: There are two different versions of the tl_expected header now, and the first one wins: 

```
#include <rsl/parameter_validators.hpp> // this includes <tl/expected.hpp>

#include "example_validators.hpp" // this includes <tl_expected/expected.hpp>
```

Include guards prevent pulling a different implementation, but as the deprecation warning from #18 is inside the guards the deprecation warning will never be printed in this case.